### PR TITLE
fixed .quantQ.io.dpftsAppend to work with kdbv4.0

### DIFF
--- a/lib/quantQ_io.q
+++ b/lib/quantQ_io.q
@@ -13,12 +13,11 @@
     @[;pvar;`p#] pvar xasc (` sv (tabPath;`;table;`)) upsert .Q.en[tabPath] table2Add
  };
 
-k).quantQ.io.dpftsAppend:{[d;p;f;t;s;o]
-    if[~&/.Q.qm'r:+.Q.enxs[$;d;;s]`. . `\:t;'`unmappable];
-    {[d;t;o;x]@[d;x;o;t x]}[d:.Q.par[d;p;t];r;o;]'[!r];
-    @[d;`.d;:;f,r@&~f=r:!r];
-    @[.q.xasc[f] d;f;`p#];
+k).quantQ.io.dpftsAppend:{[d;p;f;t;s;o]r:+.Q.enxs[$;d;;s]`. . `\:t;{[d;t;o;x]@[d;x;o; t[x]]}[d:.Q.par[d;p;t];r;o]'[!r];
+ @[d;`.d;:;f,r@&~f=r:!r];
+ @[.q.xasc[f] d;f;`p#];
  t};
+
 
 
 


### PR DESCRIPTION
I have been reading this book and found that .quantQ.io.dpftsAppend uses .Q.qm which was used when kdb was unable to map certain data types into memory, This feature now exists in new versions of kdb and I have updated the code to use .Q.dpfts from Kdbv4.0. Please merge if happy. :)

